### PR TITLE
fix: detach cache HEAD before adding worktrees

### DIFF
--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 
 	"github.com/rohankmr414/grove/internal/util"
@@ -9,6 +10,10 @@ import (
 
 func AddWorktree(ctx context.Context, canonicalPath, worktreePath, branch, defaultBranch string) error {
 	if err := util.EnsureDir(filepath.Dir(worktreePath)); err != nil {
+		return err
+	}
+
+	if err := DetachHead(ctx, canonicalPath); err != nil {
 		return err
 	}
 
@@ -29,4 +34,21 @@ func CanonicalRoot(ctx context.Context, repoPath string) (string, error) {
 		return "", err
 	}
 	return filepath.Dir(commonDir), nil
+}
+
+func DetachHead(ctx context.Context, canonicalPath string) error {
+	head, err := util.Output(ctx, "git", "-C", canonicalPath, "symbolic-ref", "--quiet", "--short", "HEAD")
+	if err != nil {
+		return nil
+	}
+
+	if head == "" {
+		return nil
+	}
+
+	if err := util.Run(ctx, "git", "-C", canonicalPath, "switch", "--detach", "--quiet"); err != nil {
+		return fmt.Errorf("detach cache HEAD at %s: %w", canonicalPath, err)
+	}
+
+	return nil
 }

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -1,0 +1,43 @@
+package git
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rohankmr414/grove/internal/util"
+)
+
+func TestDetachHead_DetachesWhenOnBranch(t *testing.T) {
+	ctx := context.Background()
+	repoPath := t.TempDir()
+
+	mustRun(t, ctx, "git", "init", repoPath)
+	mustRun(t, ctx, "git", "-C", repoPath, "config", "user.name", "Test User")
+	mustRun(t, ctx, "git", "-C", repoPath, "config", "user.email", "test@example.com")
+
+	filePath := filepath.Join(repoPath, "README.md")
+	if err := os.WriteFile(filePath, []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	mustRun(t, ctx, "git", "-C", repoPath, "add", "README.md")
+	mustRun(t, ctx, "git", "-C", repoPath, "commit", "-m", "initial")
+
+	if err := DetachHead(ctx, repoPath); err != nil {
+		t.Fatalf("DetachHead returned error: %v", err)
+	}
+
+	headRef, err := util.Output(ctx, "git", "-C", repoPath, "symbolic-ref", "--quiet", "HEAD")
+	if err == nil {
+		t.Fatalf("expected detached HEAD, still attached to %q", headRef)
+	}
+}
+
+func mustRun(t *testing.T, ctx context.Context, name string, args ...string) {
+	t.Helper()
+	if err := util.Run(ctx, name, args...); err != nil {
+		t.Fatalf("%s %v: %v", name, args, err)
+	}
+}


### PR DESCRIPTION
### Motivation

- Prevent cached repository clones from staying checked out on their default branch, which can cause `git worktree` branch-in-use errors when creating workspace worktrees.

### Description

- Call the new `DetachHead` helper from `AddWorktree` to ensure the canonical cached clone is detached before running `git worktree add`.
- Add `DetachHead(ctx, canonicalPath)` in `internal/git/worktree.go`, which no-ops when HEAD is already detached and runs `git switch --detach --quiet` when attached, returning a wrapped error on failure.
- Add `TestDetachHead_DetachesWhenOnBranch` in `internal/git/worktree_test.go` to verify a repo with an initial commit is detached after calling `DetachHead`.

### Testing

- Ran `gofmt -w internal/git/worktree.go internal/git/worktree_test.go` and `go test ./...`, and all tests succeeded (packages `internal/git`, `internal/ui`, `internal/workspace`, and `internal/cli` reported OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b16cf5d470832886223b1959af72b2)