### PR TITLE
Populate VSCode `git.scanRepositories` with workspace sub-repositories and add tests

### DIFF
--- a/internal/workspace/vscode.go
+++ b/internal/workspace/vscode.go
@@ -2,8 +2,10 @@ package workspace
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/rohankmr414/grove/internal/util"
 )
@@ -37,6 +39,12 @@ func (m Manager) writeVSCodeSettings(ws Workspace) error {
 		settings[key] = value
 	}
 
+	repositories, err := workspaceRepositories(ws.Path)
+	if err != nil {
+		return err
+	}
+	settings["git.scanRepositories"] = repositories
+
 	if err := util.EnsureDir(filepath.Dir(settingsPath)); err != nil {
 		return err
 	}
@@ -47,4 +55,31 @@ func (m Manager) writeVSCodeSettings(ws Workspace) error {
 	}
 	data = append(data, '\n')
 	return os.WriteFile(settingsPath, data, 0o644)
+}
+
+func workspaceRepositories(workspacePath string) ([]string, error) {
+	entries, err := os.ReadDir(workspacePath)
+	if err != nil {
+		return nil, fmt.Errorf("read workspace directory: %w", err)
+	}
+
+	repositories := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() || entry.Name() == ".vscode" {
+			continue
+		}
+
+		gitPath := filepath.Join(workspacePath, entry.Name(), ".git")
+		if _, err := os.Stat(gitPath); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("check git metadata for %q: %w", entry.Name(), err)
+		}
+
+		repositories = append(repositories, entry.Name())
+	}
+
+	sort.Strings(repositories)
+	return repositories, nil
 }

--- a/internal/workspace/vscode_test.go
+++ b/internal/workspace/vscode_test.go
@@ -36,15 +36,7 @@ func TestSyncEditorWorkspaceWritesVSCodeMetadata(t *testing.T) {
 		t.Fatalf("sync editor workspace: %v", err)
 	}
 
-	settingsData, err := os.ReadFile(filepath.Join(ws.Path, ".vscode", "settings.json"))
-	if err != nil {
-		t.Fatalf("read settings: %v", err)
-	}
-
-	var settings map[string]any
-	if err := json.Unmarshal(settingsData, &settings); err != nil {
-		t.Fatalf("unmarshal settings: %v", err)
-	}
+	settings := readVSCodeSettings(t, ws.Path)
 	if settings["editor.tabSize"] != float64(2) {
 		t.Fatalf("expected existing setting to survive, got %#v", settings["editor.tabSize"])
 	}
@@ -53,5 +45,72 @@ func TestSyncEditorWorkspaceWritesVSCodeMetadata(t *testing.T) {
 	}
 	if settings["git.repositoryScanMaxDepth"] != float64(2) {
 		t.Fatalf("expected git.repositoryScanMaxDepth=2, got %#v", settings["git.repositoryScanMaxDepth"])
+	}
+
+	assertScanRepositories(t, settings, []string{"api", "web"})
+}
+
+func TestSyncEditorWorkspaceRefreshesScanRepositoriesAfterRepoAdd(t *testing.T) {
+	root := t.TempDir()
+	ws := Workspace{
+		Name: "feature-x",
+		Path: filepath.Join(root, "feature-x"),
+	}
+
+	if err := os.MkdirAll(filepath.Join(ws.Path, "api"), 0o755); err != nil {
+		t.Fatalf("create api repo dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(ws.Path, "api", ".git"), []byte("gitdir: /tmp/api\n"), 0o644); err != nil {
+		t.Fatalf("seed .git for api: %v", err)
+	}
+
+	manager := Manager{}
+	if err := manager.syncEditorWorkspace(ws); err != nil {
+		t.Fatalf("first sync editor workspace: %v", err)
+	}
+	assertScanRepositories(t, readVSCodeSettings(t, ws.Path), []string{"api"})
+
+	if err := os.MkdirAll(filepath.Join(ws.Path, "web"), 0o755); err != nil {
+		t.Fatalf("create web repo dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(ws.Path, "web", ".git"), []byte("gitdir: /tmp/web\n"), 0o644); err != nil {
+		t.Fatalf("seed .git for web: %v", err)
+	}
+
+	if err := manager.syncEditorWorkspace(ws); err != nil {
+		t.Fatalf("second sync editor workspace: %v", err)
+	}
+	assertScanRepositories(t, readVSCodeSettings(t, ws.Path), []string{"api", "web"})
+}
+
+func readVSCodeSettings(t *testing.T, workspacePath string) map[string]any {
+	t.Helper()
+
+	settingsData, err := os.ReadFile(filepath.Join(workspacePath, ".vscode", "settings.json"))
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal(settingsData, &settings); err != nil {
+		t.Fatalf("unmarshal settings: %v", err)
+	}
+	return settings
+}
+
+func assertScanRepositories(t *testing.T, settings map[string]any, expected []string) {
+	t.Helper()
+
+	scanRepositories, ok := settings["git.scanRepositories"].([]any)
+	if !ok {
+		t.Fatalf("expected git.scanRepositories to be an array, got %#v", settings["git.scanRepositories"])
+	}
+	if len(scanRepositories) != len(expected) {
+		t.Fatalf("expected git.scanRepositories length %d, got %d", len(expected), len(scanRepositories))
+	}
+	for i := range expected {
+		if scanRepositories[i] != expected[i] {
+			t.Fatalf("expected git.scanRepositories=%v, got %#v", expected, scanRepositories)
+		}
 	}
 }


### PR DESCRIPTION
### Motivation
- Ensure the workspace `.vscode/settings.json` explicitly lists workspace sub-repositories so VS Code will scan them when opening the workspace root. 
- Ensure the repository list is refreshed when repos are added to the workspace so the editor view stays up to date.

### Description
- Added `workspaceRepositories` which scans immediate subdirectories for a `.git` entry and returns a sorted list of repository names. 
- Wire the discovered list into `writeVSCodeSettings` as `git.scanRepositories` and preserve existing settings while applying `vscodeGitSettings`. 
- Updated imports to include `fmt` and `sort`. 
- Refactored and extended tests by adding `readVSCodeSettings` and `assertScanRepositories`, updating `TestSyncEditorWorkspaceWritesVSCodeMetadata`, and adding `TestSyncEditorWorkspaceRefreshesScanRepositoriesAfterRepoAdd` to validate dynamic refresh behavior.

### Testing
- Ran `go test ./internal/workspace -v` which executed the workspace tests. 
- The updated `TestSyncEditorWorkspaceWritesVSCodeMetadata` and the new `TestSyncEditorWorkspaceRefreshesScanRepositoriesAfterRepoAdd` both passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3ee7644e08328bdd724e7d9744ed4)