### PR TITLE
ci: add pull request verification workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: ci
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify (Go)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Check formatting
+        run: |
+          unformatted="$(gofmt -l .)"
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not gofmt-formatted:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Run go vet
+        run: go vet ./...
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Build CLI
+        run: go build -v ./cmd/grove


### PR DESCRIPTION
### Motivation
- Ensure every pull request runs formatting, vetting, tests, and a build so regressions are caught early.

### Description
- Add `.github/workflows/ci.yml` which runs on `pull_request` and `workflow_dispatch`, sets up Go from `go.mod` with caching, and runs a `gofmt` check, `go vet ./...`, `go test ./...`, and `go build -v ./cmd/grove`.

### Testing
- Ran `go test ./...` which passed, and validated `go vet ./...`, `go build -v ./cmd/grove`, and `test -z "$(gofmt -l .)"`, all of which succeeded locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f15aa3d0832896aa118de1abf821)